### PR TITLE
Config `circleci` requirement for pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@
  - [x] badge for `public` build status
  - [ ] badge for `private` build status (need to test with API TOKEN)
  - [ ] badge for test coverage
- - [ ] config `required` for `pull request` (setting in `Settings > Branches`)
+ - [x] config `required` for `pull request` (setting in `Settings > Branches`)


### PR DESCRIPTION
Expected: all will be good to merge pull request, 'cause all `circleci` jobs should pass